### PR TITLE
Reek template para utilizar con la gema RubyCritic

### DIFF
--- a/config.reek
+++ b/config.reek
@@ -1,0 +1,59 @@
+# Rubycritic Smell configuration: Reek Gem
+# Visit http://www.rubydoc.info/github/troessner/reek/Reek for more info.
+#
+# Important! If you are working with Docker, maybe you want to skip volumes folder with:
+# rubycritc $(ls | grep -v volumes)
+#
+
+### Custom Reek smell configuration
+#
+# Excluding directories
+# Directories below will not be scanned at all
+exclude_paths:
+  - db
+
+### Reek Smells ###
+#
+# Avoid documentation at top of classes. But if you want to write it, you are free to do it!
+#
+IrresponsibleModule:
+  enabled: false
+
+# This smells are so common and anoying to solve.
+#
+FeatureEnvy:
+  enabled: false
+Attribute:
+  enabled: false
+
+# This smells are common too, but there are important to know and solve. If you want, you could 
+# change them to false to skip them.
+#
+NestedIterators:
+  enabled: true
+BooleanParameter:
+  enabled: true
+UncommunicativeMethodName:
+  enabled: true
+UncommunicativeParameterName:
+  enabled: true
+UncommunicativeModuleName:
+  enabled: true
+UncommunicativeVariableName:
+  enabled: true
+
+### Metrics ###
+#
+# Change this in your legacy projects to skip refactor methods and classes. For new projects, just
+# delete this block and try to write code with default Reek rules.
+#
+TooManyInstanceVariables:
+  max_instance_variables: 9
+TooManyStatements:
+  max_statements: 5
+TooManyMethods:
+  max_methods: 25
+DuplicateMethodCall:
+  max_calls: 3
+LongParameterList:
+  max_parameters: 3


### PR DESCRIPTION
Añado el template para configurar reek en el entorno de RubyCritic, igual que el template para rubocop. Las opciones son las definidas por defecto pero están listas para poder ser personalizadas por proyecto.