### PR TITLE
Removes directories files and hidden files in reports folder to avoid simplecov errors

### DIFF
--- a/Ruby/simplecov.md
+++ b/Ruby/simplecov.md
@@ -47,3 +47,18 @@ Jenkinsfile
     reportName: 'Test Coverage Report'
   ]
  ```
+
+### Posibles errores en Jenkins
+
+ Si se producen errores de permisos en la generación de los informes de simplecov, se puede añadir un paso que fuerce el borrado de los reports antes de apagar el contenedor de la ejecución.
+
+
+ Jenkinsfile
+```
+  post {
+    always {
+      sh 'docker-compose -f docker-compose-jenkins.yml run --rm web rm -rf /app/reports/*'
+      sh 'docker-compose -f docker-compose-jenkins.yml run --rm web rm -rf /app/reports/.*'
+      sh 'docker-compose -f docker-compose-jenkins.yml down -v'
+    }
+ ```


### PR DESCRIPTION
En algunos builds se observó que existe un error en la generación del report de simplecov
```
/usr/local/lib/ruby/gems/2.3.0/gems/simplecov-0.16.1/lib/simplecov/result_merger.rb:108:in `initialize': Permission denied @ rb_sysopen - /app/reports/simplecov/.resultset.json.lock (Errno::EACCES)
    from /usr/local/lib/ruby/gems/2.3.0/gems/simplecov-0.16.1/lib/simplecov/result_merger.rb:108:in `open'
    from /usr/local/lib/ruby/gems/2.3.0/gems/simplecov-0.16.1/lib/simplecov/result_merger.rb:108:in `synchronize_resultset'
    from /usr/local/lib/ruby/gems/2.3.0/gems/simplecov-0.16.1/lib/simplecov/result_merger.rb:87:in `store_result'
    from /usr/local/lib/ruby/gems/2.3.0/gems/simplecov-0.16.1/lib/simplecov.rb:93:in `result'
    from /usr/local/lib/ruby/gems/2.3.0/gems/simplecov-0.16.1/lib/simplecov/configuration.rb:182:in `block in at_exit'
    from /usr/local/lib/ruby/gems/2.3.0/gems/simplecov-0.16.1/lib/simplecov.rb:200:in `run_exit_tasks!'
    from /usr/local/lib/ruby/gems/2.3.0/gems/simplecov-0.16.1/lib/simplecov/defaults.rb:27:in `block in <top (required)>'
```
Sistemas sugiere que se fuerce el borrado de directorios/archivos/archivos ocultos que haya dentro de la carpeta **reports** para evitar conflictos.

Se recomienda la inclusión dentro del **Jenkinsfile** si se diese este tipo de errores.