### PR TITLE
Adds audit vulnerabilities scanning

### DIFF
--- a/Ruby/bundle_audit.md
+++ b/Ruby/bundle_audit.md
@@ -1,6 +1,6 @@
 # Análisis de vulnerabilidades con Audit
 
-Con esta gema podremos conocer las vulnerabilidades de seguridad asociadas a nuestro árbol de dependencias.
+Con esta gema podremos conocer las vulnerabilidades de seguridad existentes asociadas a nuestro árbol de dependencias.
 
 ## Instalación
 
@@ -36,13 +36,46 @@ Jenkinsfile
             echo 'Building...'
             sh 'docker-compose -f docker-compose-jenkins.yml build'
 
-            sh 'docker-compose -f docker-compose-jenkins.yml run --rm web bundle audit update'
-            sh 'docker-compose -f docker-compose-jenkins.yml run --rm web bundle audit'
+            sh 'docker-compose -f docker-compose-jenkins.yml run --rm web sh .audit.sh'
             }
  ```
 
+ Esto requiere que antes se haya creado un archivo `.audit.sh` en la raiz del proyecto con el siguiente contenido
+
+ ```
+    #!/usr/bin/env sh
+    bundle exec bundle-audit update
+    bundle exec bundle-audit
+ ```
  Si existen vulnerabilidades devolverá un exit 1 e interrumpirá la ejecución.
 
- Algunas vulnerabilidades son muy difíciles de corregir, por lo que este proceso es muy restrictivo.
+ Se lanza mediante un script ya que el lanzar los comandos `audit` directamente sobre el contenedor no dan el resultado esperado, ya que hay algunos conflictos.
 
- Si se llega al punto de tener alguna vulnerabilidad imposible de corregir en nuestro proyecto, se deberían comentar/eliminar las referencias a audit dentro del Jenkinsfile
+ ### Añadir excepciones
+ 
+ En el caso de encontrar alguna vulnerabilidad que no se puede solucionar en el momento, existe una manera de hacer que audit la ignore.
+ 
+ La sintaxis sera de este tipo:
+ 
+ `bundle audit --ignore CVE-2018-16476`
+ 
+donde se le pase el identificador de vulnerabilidad que te haya devuelto al pasar el audit.
+Un ejemplo:
+```
+Name: activejob
+Version: 4.2.10
+Advisory: CVE-2018-16476
+Criticality: Unknown
+URL: https://groups.google.com/forum/#!topic/rubyonrails-security/FL4dSdzr2zw
+Title: Broken Access Control vulnerability in Active Job
+Solution: upgrade to ~> 4.2.11, ~> 5.0.7.1, ~> 5.1.6.1, >= 5.2.1.1
+```
+En el siguiente escaneo ya no aparecería esta vulnerabilidad y el build de Jenkins pasaría sin problemas.
+
+ ```
+    #!/usr/bin/env sh
+    bundle exec bundle-audit update
+    bundle exec bundle-audit --ignore  CVE-2018-16476
+ ```
+
+De esta manera se lanzaría el script del audit ignorando la vulnerabilidad que no se ha podido resolver.


### PR DESCRIPTION
La anterior sintáxis sugerida lanzando los comandos de audit no funciona según lo esperado ya que son lanzadas en distintos contenedores, y la actualización interna de vulnerabilidades no es encontrada en el siguiente paso, por lo que nunca se devuleve un código exit 1.
Se crea script genérico en la raíz del proyecto que lance dichos comandos asegurando que corren en el mismo contenedor.